### PR TITLE
Add Cast_Array and Cast_Object nodes to parser

### DIFF
--- a/PHP.js
+++ b/PHP.js
@@ -11103,6 +11103,24 @@ PHP.Parser.prototype.Node_Expr_Cast_Double = function() {
 
 };
 
+PHP.Parser.prototype.Node_Expr_Cast_Array = function() {
+    return {
+        type: "Node_Expr_Cast_Array",
+        expr: arguments[ 0 ],
+        attributes: arguments[ 1 ]
+    };
+
+};
+
+PHP.Parser.prototype.Node_Expr_Cast_Object = function() {
+    return {
+        type: "Node_Expr_Cast_Object",
+        expr: arguments[ 0 ],
+        attributes: arguments[ 1 ]
+    };
+
+};
+
 
 PHP.Parser.prototype.Node_Expr_ErrorSuppress = function() {
     return {

--- a/src/parser/yyn_expr.js
+++ b/src/parser/yyn_expr.js
@@ -524,6 +524,24 @@ PHP.Parser.prototype.Node_Expr_Cast_Double = function() {
 
 };
 
+PHP.Parser.prototype.Node_Expr_Cast_Array = function() {
+    return {
+        type: "Node_Expr_Cast_Array",
+        expr: arguments[ 0 ],
+        attributes: arguments[ 1 ]
+    };
+
+};
+
+PHP.Parser.prototype.Node_Expr_Cast_Object = function() {
+    return {
+        type: "Node_Expr_Cast_Object",
+        expr: arguments[ 0 ],
+        attributes: arguments[ 1 ]
+    };
+
+};
+
 
 PHP.Parser.prototype.Node_Expr_ErrorSuppress = function() {
     return {


### PR DESCRIPTION
I just added lacking nodes to parser (to get it working), of course we should implement these feauters in the `compiler`

This applies to https://github.com/niklasvh/php.js/issues/20
